### PR TITLE
Update rustix version to 0.38.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.0",
  "errno",

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -23,7 +23,6 @@ use std::{
 	thread::{self, JoinHandle},
 	thread_local,
 	time::{Duration, Instant},
-	usize,
 };
 
 use log::{error, trace, warn};


### PR DESCRIPTION
The current version of rustix (0.38.17) contains a vulnerability: https://github.com/advisories/ghsa-c827-hfw6-qwvm.

This change bumps the version to 0.38.21.